### PR TITLE
perf: reduce memory allocations by `UI::concat<const N>` instead of `FromIterator`

### DIFF
--- a/sandbox/examples/hello_world.rs
+++ b/sandbox/examples/hello_world.rs
@@ -29,21 +29,6 @@ impl Beam for Hello {
     }
 }
 
-struct Counter {
-    initial_count: u32,
-}
-impl Beam for Counter {
-    fn render(self) -> UI {
-        UI! {
-            <div id="counter">
-                <a id="" class=""></a>
-                <button id=""></button>
-            </div>
-            <p></p>
-        }
-    }
-}
-
 fn main() {
     println!("{}", uibeam::shoot(UI! {
         <body>

--- a/uibeam_macro/src/ui/mod.rs
+++ b/uibeam_macro/src/ui/mod.rs
@@ -18,8 +18,6 @@ pub(super) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     });
 
     Ok(quote! {
-        <::uibeam::UI as ::std::iter::FromIterator::<::uibeam::UI>>::from_iter([
-            #(#nodes),*
-        ])
+        <::uibeam::UI>::concat([#(#nodes),*])
     })
 }


### PR DESCRIPTION
While `FromIterator` collects arbitrary `UI` iterator just by `push_str` to `String::new()`, `UI::concan` method takes an array of `UI`s of constantly-fixed length and be able to allocate needed memory by single `String::with_capacity(...)`, avoiding redundant re-allocations.

`UI!` knows the number of `UI`s to be concatinated in the emitted code, so this method is useful in it.