### PR TITLE
perf(UI): `new_unchecked` size in separated steps

### DIFF
--- a/uibeam/src/lib.rs
+++ b/uibeam/src/lib.rs
@@ -124,11 +124,11 @@ impl UI {
 
                 let mut buf = String::with_capacity({
                     let mut size = 0;
-                    for i in 0..=N {
-                        size += template_pieces[i].len();
+                    for piece in template_pieces {
+                        size += piece.len();
                     }
-                    for i in 0..N {
-                        size += match &interpolators[i] {
+                    for expression in &interpolators {
+                        size += match expression {
                             Interpolator::Children(children) => children.0.len(),
                             Interpolator::Attribute(value) => match value {
                                 AttributeValue::Text(text) => {

--- a/uibeam/src/lib.rs
+++ b/uibeam/src/lib.rs
@@ -124,8 +124,10 @@ impl UI {
 
                 let mut buf = String::with_capacity({
                     let mut size = 0;
-                    for i in 0..N {
+                    for i in 0..=N {
                         size += template_pieces[i].len();
+                    }
+                    for i in 0..N {
                         size += match &interpolators[i] {
                             Interpolator::Children(children) => children.0.len(),
                             Interpolator::Attribute(value) => match value {
@@ -141,7 +143,7 @@ impl UI {
                             }
                         }
                     }
-                    size + template_pieces[N].len()
+                    size
                 });
 
                 for i in 0..N {


### PR DESCRIPTION
Currently, `UI::new_unchecked` calculated the buffer size by iterating over `template_pieces` and `interpolators` at the same time by indexing.

But it can be improved for modern computers:

1. First, iterate directly over `template_pieces: &'static [&'static str]` and increase buffer size.
2. Next, iterate directly over `&interpolators: &[Interpolator; N]` and increase buffer size.

This is better than current implementation because:

* This doesn't need `for i in 0..N` and `[i]` indexing.
* Simple sequential access to each slices is more friendly for modern CPU & memory.