### PR TITLE
docs: surround urls in doc comments by angle bracket ( `<>` )

### DIFF
--- a/uibeam_macros/src/lib.rs
+++ b/uibeam_macros/src/lib.rs
@@ -5,7 +5,7 @@ mod ui;
 /// # `UI!` - JSX-style template syntax
 /// 
 /// > HTML completions and hovers are available by VSCode extension.\
-/// > ( search "_uibeam_" from extension marketplace, or see https://marketplace.visualstudio.com/items?itemName=ohkami-rs.uibeam )
+/// > ( search "_uibeam_" from extension marketplace, or see <https://marketplace.visualstudio.com/items?itemName=ohkami-rs.uibeam> )
 /// 
 /// ## Usage
 /// 


### PR DESCRIPTION
so that rustdoc automatically recognizes them as URLs