### PR TITLE
feat: export `uibeam::escape` as a utility

### DIFF
--- a/uibeam/src/lib.rs
+++ b/uibeam/src/lib.rs
@@ -19,8 +19,8 @@
 //! ![](https://github.com/ohkami-rs/uibeam/raw/HEAD/support/vscode/assets/completion.png)
 
 use std::borrow::Cow;
-use uibeam_html::html_escape;
 
+pub use uibeam_html::escape;
 pub use uibeam_macros::UI;
 
 /// # `UI` - UIBeam's template representation
@@ -302,7 +302,7 @@ const _: () = {
     impl<D: std::fmt::Display> IntoChildren<&dyn std::fmt::Display> for D {
         fn into_children(self) -> UI {
             let s = self.to_string();
-            match html_escape(&s) {
+            match escape(&s) {
                 Cow::Owned(escaped) => {
                     UI(Cow::Owned(escaped))
                 }
@@ -387,7 +387,7 @@ impl UI {
                             match value {
                                 AttributeValue::Text(text) => {
                                     buf.push('"');
-                                    buf.push_str(&html_escape(text));
+                                    buf.push_str(&escape(text));
                                     buf.push('"');
                                 }
                                 AttributeValue::Integer(int) => {
@@ -458,40 +458,6 @@ mod test {
         is_children((1..=3).map(|_| dummy_ui()));
     }
     
-    #[test]
-    fn test_html_escape() {
-        let test_cases = [
-            ("", ""),
-            ("abc", "abc"),
-            ("おはよう", "おはよう"),
-            ("&", "&amp;"),
-            ("<", "&lt;"),
-            (">", "&gt;"),
-            ("\"", "&#34;"),
-            ("'", "&#39;"),
-            (
-                "a&b<c>d\"'e",
-                "a&amp;b&lt;c&gt;d&#34;&#39;e"
-            ),
-            (
-                "a&b<c>d\"'e&f<g>h\"'i",
-                "a&amp;b&lt;c&gt;d&#34;&#39;e&amp;f&lt;g&gt;h&#34;&#39;i"
-            ),
-            (
-                "flowers <script>evil_script()</script>",
-                "flowers &lt;script&gt;evil_script()&lt;/script&gt;"
-            ),
-            (
-                "こんにちは <script>console.alert('ぼくはまちちゃん')</script>",
-                "こんにちは &lt;script&gt;console.alert(&#39;ぼくはまちちゃん&#39;)&lt;/script&gt;"
-            ),
-        ];
-        
-        for (input, expected) in test_cases {
-            assert_eq!(html_escape(input), expected);
-        }
-    }
-
     #[test]
     fn test_ui_new_unchecked() {
         assert_eq!(

--- a/uibeam_html/src/lib.rs
+++ b/uibeam_html/src/lib.rs
@@ -1,7 +1,20 @@
 use std::borrow::Cow;
 
+/// Escapes HTML special characters in a string.
+/// 
+/// This function replaces the following characters with their HTML
+/// entity equivalents:
+///
+/// * `&` -> `&amp;`
+/// * `<` -> `&lt;`
+/// * `>` -> `&gt;`
+/// * `"` -> `&#34;`
+/// * `'` -> `&#39;`
+/// 
+/// When the input string does not contain any special characters,
+/// it just returns a borrowed reference to the original string.
 #[inline]
-pub fn html_escape(s: &str) -> Cow<'_, str> {
+pub fn escape(s: &str) -> Cow<'_, str> {
     let mut first_special = None;
     for i in 0..s.len() {
         match &s.as_bytes()[i] {
@@ -34,9 +47,48 @@ pub fn html_escape(s: &str) -> Cow<'_, str> {
             // SAFETY: `escaped` is a valid UTF-8 bytes because:
             // 
             // - original `s` is valid UTF-8
-            // - we just replaced some ascii bytes with valid UTF-8 bytes
+            // - we just replaced some ASCII bytes with valid UTF-8 bytes
             // - the rest of `escaped` is unchanged, directly copied from `s`
             Cow::Owned(unsafe {String::from_utf8_unchecked(escaped)})
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape() {
+        let test_cases = [
+            ("", ""),
+            ("abc", "abc"),
+            ("おはよう", "おはよう"),
+            ("&", "&amp;"),
+            ("<", "&lt;"),
+            (">", "&gt;"),
+            ("\"", "&#34;"),
+            ("'", "&#39;"),
+            (
+                "a&b<c>d\"'e",
+                "a&amp;b&lt;c&gt;d&#34;&#39;e"
+            ),
+            (
+                "a&b<c>d\"'e&f<g>h\"'i",
+                "a&amp;b&lt;c&gt;d&#34;&#39;e&amp;f&lt;g&gt;h&#34;&#39;i"
+            ),
+            (
+                "flowers <script>evil_script()</script>",
+                "flowers &lt;script&gt;evil_script()&lt;/script&gt;"
+            ),
+            (
+                "こんにちは <script>console.alert('ぼくはまちちゃん')</script>",
+                "こんにちは &lt;script&gt;console.alert(&#39;ぼくはまちちゃん&#39;)&lt;/script&gt;"
+            ),
+        ];
+        
+        for (input, expected) in test_cases {
+            assert_eq!(escape(input), expected);
         }
     }
 }

--- a/uibeam_macros/src/ui/transform.rs
+++ b/uibeam_macros/src/ui/transform.rs
@@ -147,7 +147,7 @@ pub(super) fn transform(
                     AttributeValueToken::StringLiteral(lit) => {
                         current_piece.join(Piece::new(format!(
                             "\"{}\"",
-                            uibeam_html::html_escape(&lit.value())
+                            uibeam_html::escape(&lit.value())
                         )));
                     }
                     AttributeValueToken::Interpolation(InterpolationTokens { rust_expression, .. }) => {
@@ -226,7 +226,7 @@ pub(super) fn transform(
                     match c {
                         ContentPieceTokens::StaticText(text) => {
                             piece.join(Piece::new(
-                                uibeam_html::html_escape(&text.value())
+                                uibeam_html::escape(&text.value())
                             ));
                         }
                         ContentPieceTokens::Interpolation(InterpolationTokens { rust_expression, .. }) => {
@@ -263,7 +263,7 @@ pub(super) fn transform(
                         ContentPieceTokens::StaticText(text) => {
                             last_was_interplolation = false;
                             piece.join(Piece::new(
-                                uibeam_html::html_escape(&text.value())
+                                uibeam_html::escape(&text.value())
                             ));
                         }
                         ContentPieceTokens::Interpolation(InterpolationTokens { rust_expression, _brace }) => {


### PR DESCRIPTION
reexport from `uibeam_html`. internally renamed from `html_escape` and documented.