### PR TITLE
fix(UI): expression just under Component

### DIFF
--- a/examples/tailwind/.gitignore
+++ b/examples/tailwind/.gitignore
@@ -1,0 +1,2 @@
+/target
+/pages

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name    = "tailwind"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+uibeam = { path = "../../uibeam" }
+
+[package.metadata.tasks]
+pages = """
+    tailwindcss -c .tailwind.config.js -o ./pages/tailwind.css
+    cargo run
+"""

--- a/examples/tailwind/src/main.rs
+++ b/examples/tailwind/src/main.rs
@@ -23,30 +23,29 @@ impl Beam for Layout {
     }
 }
 
-fn _test() {
-    let _ = UI! {
-        {"Hello world!"}
-    };
-}
-
 fn main() -> std::io::Result<()> {
     let pages_dir = std::path::Path::new("pages");
 
     for (path, page) in pages::pages() {
-        let path = path
-            .trim_matches('/')
-            .with_extension("html");
-
-        let page = UI! {
+        let page = uibeam::shoot(UI! {
             <Layout>
                 {page()}
             </Layout>
-        };
+        });
 
-        std::fs::write(
-            pages_dir.join(path),
-            uibeam::shoot(page).as_bytes()
-        )?;
+        let path = pages_dir.join(format!(
+            ".{}.html",
+            if *path == "/" {"/index"} else {path}
+        ));
+
+        // Create the directory if it doesn't exist
+        let parent = path.parent().unwrap();
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Write the HTML to the file
+        std::fs::write(path, page.as_bytes())?;
     }
 
     Ok(())

--- a/examples/tailwind/src/main.rs
+++ b/examples/tailwind/src/main.rs
@@ -1,0 +1,53 @@
+mod pages;
+
+use uibeam::{UI, Beam};
+
+struct Layout {
+    children: UI,
+}
+impl Beam for Layout {
+    fn render(self) -> UI {
+        UI! {
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <link rel="stylesheet" href="./tailwind.css">
+                <title>"Ohkami organization"</title>
+            </head>
+            <body>
+                {self.children}
+            </body>
+            </html>
+        }
+    }
+}
+
+fn _test() {
+    let _ = UI! {
+        {"Hello world!"}
+    };
+}
+
+fn main() -> std::io::Result<()> {
+    let pages_dir = std::path::Path::new("pages");
+
+    for (path, page) in pages::pages() {
+        let path = path
+            .trim_matches('/')
+            .with_extension("html");
+
+        let page = UI! {
+            <Layout>
+                {page()}
+            </Layout>
+        };
+
+        std::fs::write(
+            pages_dir.join(path),
+            uibeam::shoot(page).as_bytes()
+        )?;
+    }
+
+    Ok(())
+}

--- a/examples/tailwind/src/pages/index.rs
+++ b/examples/tailwind/src/pages/index.rs
@@ -1,0 +1,61 @@
+use uibeam::{UI, Beam};
+
+struct ContactList {
+    contacts: Vec<Contact>,
+}
+struct Contact {
+    title: &'static str,
+    address: &'static str,
+    href: &'static str,
+}
+impl Beam for ContactList {
+    fn render(self) -> UI {
+        UI! {
+            <div class="w-screen flex flex-col items-center">
+                <h2 class="text-2xl font-bold my-4">
+                    "Contact"
+                </h2>
+                {self.contacts.iter().map(|c| UI! {
+                    <p>
+                        {c.title}": "
+                        <a
+                            class="text-blue-500 hover:underline"
+                            href={c.href}
+                        >
+                            {c.address}
+                        </a>
+                    </p>
+                })}
+            </div>
+        }
+    }
+}
+
+pub(super) fn page() -> UI {
+    UI! {
+        <h1 class="w-screen text-center text-3xl font-bold my-8">
+            "Ohkami organization"
+        </h1>
+
+        <p class="w-screen text-center text-lg my-8">
+            "The intuitive solutions for Rust web development"
+        </p>
+
+        <ContactList contacts={[
+            Contact {
+                title: "GitHub",
+                address: "ohkami-rs",
+                href: "https://github.com/ohkami-rs",
+            },
+            Contact {
+                title: "Email",
+                address: "contact@ohkami.rs",
+                href: "mailto:contact@ohkami.rs",
+            },
+        ]} />
+
+        <p class="w-screen text-right text-sm font-bold my-8">
+            <i>"This page is under construction..."</i>
+        </p>
+    }
+}

--- a/examples/tailwind/src/pages/mod.rs
+++ b/examples/tailwind/src/pages/mod.rs
@@ -1,0 +1,7 @@
+mod index;
+
+pub(super) const fn pages() -> &'static [(&'static str, fn() -> uibeam::UI)] {
+    &[
+        ("/", index::page),
+    ]
+}

--- a/examples/tailwind/src/pages/mod.rs
+++ b/examples/tailwind/src/pages/mod.rs
@@ -3,5 +3,7 @@ mod index;
 pub(super) const fn pages() -> &'static [(&'static str, fn() -> uibeam::UI)] {
     &[
         ("/", index::page),
+        ("/test", index::page),
+        ("/test/test2", index::page),
     ]
 }

--- a/examples/tailwind/tailwind.config.js
+++ b/examples/tailwind/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    content: [
+        "./src/**/*.{rs,html,css}",
+    ],
+    theme: {},
+    variants: {},
+    plugins: [],
+};

--- a/uibeam/src/lib.rs
+++ b/uibeam/src/lib.rs
@@ -322,7 +322,7 @@ impl UI {
     /// 
     /// ## SAFETY
     /// 
-    /// 1. `template_pieces` must have 0 or exactly `N + 1` pieces.
+    /// 1. `template_pieces` must have 0 = N or exactly `N + 1` pieces.
     /// 2. `template_pieces` must be concatenated into
     ///    a valid HTML string with any `interpolators` in place.
     /// 3. Each piece in `template_pieces` must be already HTML-escaped.
@@ -332,17 +332,18 @@ impl UI {
         template_pieces: &'static [&'static str],
         interpolators: [Interpolator; N],
     ) -> Self {
+        #[cfg(debug_assertions)] {
+            let len = template_pieces.len();
+            assert!(
+                (len == 0 && N == 0) || len == N + 1,
+                "invalid template_pieces.len(): {len} where N = {N}: template_pieces must have 0 = N or exactly N + 1 pieces"
+            );
+        }
+
         match template_pieces.len() {
             0 => UI::EMPTY,
             1 => UI(Cow::Borrowed(template_pieces[0])),
             _ => {
-                #[cfg(debug_assertions)] {
-                    assert!(
-                        template_pieces.len() == N + 1,
-                        "template_pieces must have 0 or exactly N + 1 pieces"
-                    );
-                }
-
                 let mut buf = String::with_capacity({
                     let mut size = 0;
                     for piece in template_pieces {
@@ -516,6 +517,84 @@ mod test {
                 ],
             )}).0,
             r##"<article class="main-article"><p>i=1</p><p>i=2</p><p>i=3</p></article>"##
+        );
+    }
+
+    #[test]
+    fn test_ui_interploate_expression() {
+        let ui = UI! {
+            {"an expression"}
+        };
+        assert_eq!(
+            shoot(ui),
+            r##"an expression"##
+        );
+
+        let ui = UI! {
+            <p>"a text node"</p>
+        };
+        assert_eq!(
+            shoot(ui),
+            r##"<p>a text node</p>"##
+        );
+
+        let ui = UI! {
+            <p>{"an expression"}</p>
+        };
+        assert_eq!(
+            shoot(ui),
+            r##"<p>an expression</p>"##
+        );
+
+        let ui = UI! {
+            <div class="foo">
+                <p>"hello"</p>
+            </div>
+        };
+        let ui = UI! {
+            <div class="bar">
+                {ui}
+            </div>
+        };
+        assert_eq!(
+            shoot(ui),
+            r##"<div class="bar"><div class="foo"><p>hello</p></div></div>"##
+        );
+
+        struct Layout {
+            children: UI,
+        }
+        impl Beam for Layout {
+            fn render(self) -> UI {
+                UI! {
+                    <html>
+                        <head>
+                            <meta charset="UTF-8">
+                        </head>
+                        <body>
+                            {self.children}
+                        </body>
+                    </html>
+                }
+            }
+        }
+
+        assert_eq!(
+            shoot(UI! { <Layout></Layout> }),
+            r##"<html><head><meta charset="UTF-8"/></head><body></body></html>"##
+        );
+
+        assert_eq!(
+            shoot(UI! { <Layout><h1>"Hello, Beam!"</h1></Layout> }),
+            r##"<html><head><meta charset="UTF-8"/></head><body><h1>Hello, Beam!</h1></body></html>"##
+        );
+
+        let content = UI! {
+            <h1>"Hello, Beam!"</h1>
+        };
+        assert_eq!(
+            shoot(UI! { <Layout>{content}"[test]"</Layout> }),
+            r##"<html><head><meta charset="UTF-8"/></head><body><h1>Hello, Beam!</h1>[test]</body></html>"##
         );
     }
 }

--- a/uibeam/src/lib.rs
+++ b/uibeam/src/lib.rs
@@ -18,6 +18,9 @@
 //! 
 //! ![](https://github.com/ohkami-rs/uibeam/raw/HEAD/support/vscode/assets/completion.png)
 
+/* for `UI!` use in this crate itself */
+extern crate self as uibeam;
+
 use std::borrow::Cow;
 
 pub use uibeam_html::escape;

--- a/uibeam_macros/src/ui/parse.rs
+++ b/uibeam_macros/src/ui/parse.rs
@@ -30,6 +30,7 @@ pub(super) enum NodeTokens {
         _end: Token![>],
     },
     TextNode(Vec<ContentPieceTokens>),
+    // Expression(InterpolationTokens),
 }
 
 pub(super) struct HtmlIdent {
@@ -173,7 +174,6 @@ impl Parse for NodeTokens {
             } else {
                 Err(input.error("Expected '>' or '/>' at the end of a tag"))
             }
-
         } else {
             let mut pieces = Vec::new();
             while let Ok(content_piece_tokens) = input.parse::<ContentPieceTokens>() {
@@ -262,10 +262,16 @@ impl Parse for AttributeValueTokens {
 impl ToTokens for ContentPieceTokens {
     fn to_tokens(&self, t: &mut proc_macro2::TokenStream) {
         match self {
-            ContentPieceTokens::Interpolation(interpolation) => interpolation.rust_expression.to_tokens(t),
-            ContentPieceTokens::StaticText(lit_str) => lit_str.to_tokens(t),
             ContentPieceTokens::Node(node) => node.to_tokens(t),
+            ContentPieceTokens::StaticText(lit_str) => lit_str.to_tokens(t),
+            ContentPieceTokens::Interpolation(interpolation) => interpolation.to_tokens(t),
         }
+    }
+}
+
+impl ToTokens for InterpolationTokens {
+    fn to_tokens(&self, t: &mut proc_macro2::TokenStream) {
+        self._brace.surround(t, |inner| self.rust_expression.to_tokens(inner));
     }
 }
 


### PR DESCRIPTION
cherry-picked

- 7343593566b9549806e0fd44014834eb525e4b4c
- 91df618871b2c91c56934987d156cbb74078a07a

from https://github.com/ohkami-rs/uibeam/pull/76

---

tested by:

- `examples/tailwind` ( via `test_examples` CI )
- `test_ui_interpolate_expression` ( via `test_crates` CI )

---

For now, expression just under Component like:

```rust
UI! {
    <Component>
        {text}
    </Component>
}
```

causes infinite loop in `UI!` internally. This PR fixes the `parse` and `transform` process to correctly handle such `UI!`s.