### PR TITLE
perf(UI): eliminate concat doctype in auto-insertion

### DIFF
--- a/uibeam_macros/src/ui/mod.rs
+++ b/uibeam_macros/src/ui/mod.rs
@@ -7,16 +7,18 @@ use quote::quote;
 pub(super) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let parse::UITokens { nodes } = syn::parse2(input)?;
 
-    let doctype_insertion = nodes.first().map(|node| match node {
+    let mut should_insert_doctype = nodes.first().is_some_and(|node| match node {
         /* starting with <html>..., without <!DOCTYPE html> */        
-        parse::NodeTokens::EnclosingTag { tag, .. } if tag.to_string() == "html" => Some(quote! {
-            unsafe {::uibeam::UI::new_unchecked(&["<!DOCTYPE html>"], [])},
-        }),
-        _ => None,
-    }).flatten();
+        parse::NodeTokens::EnclosingTag { tag, .. } if tag.to_string() == "html" => true,
+        _ => false,
+    });
 
     let nodes = nodes.into_iter().map(|node| {
-        let (literals, expressions) = transform::transform(node);
+        let (mut literals, expressions) = transform::transform(node);
+        if should_insert_doctype {
+            literals.first_mut().unwrap().edit(|lit| *lit = format!("<!DOCTYPE html>{lit}"));
+            should_insert_doctype = false;
+        }
         quote! {
             unsafe {::uibeam::UI::new_unchecked(
                 &[#(#literals),*],
@@ -26,9 +28,6 @@ pub(super) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     });
 
     Ok(quote! {
-        <::uibeam::UI>::concat([
-            #doctype_insertion
-            #(#nodes),*
-        ])
+        <::uibeam::UI>::concat([#(#nodes),*])
     })
 }

--- a/uibeam_macros/src/ui/transform.rs
+++ b/uibeam_macros/src/ui/transform.rs
@@ -74,6 +74,10 @@ impl Piece {
             pieces.push(Piece::new(text));
         }
     }
+
+    pub(super) fn edit(&mut self, f: impl FnOnce(&mut String)) {
+        self.0.as_mut().map(f);
+    }
 }
 
 pub(super) enum Interpolation {


### PR DESCRIPTION
In automatic doctype insertion ( #83 ), the doctype is always inserted as a `UI` and concat with other `UI`s.

But we can avoid the cost of concat by editing the first *piece*, in `UI!`'s internal, to start with `<!DOCTYPE html>` when it started with `<html...` !