### PR TITLE
perf(UI): eliminate concat doctype also in explicit written one

### DIFF
--- a/uibeam_macros/src/ui/mod.rs
+++ b/uibeam_macros/src/ui/mod.rs
@@ -5,7 +5,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 pub(super) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
-    let parse::UITokens { nodes } = syn::parse2(input)?;
+    let parse::UITokens { mut nodes } = syn::parse2(input)?;
+
+    if nodes.first().is_some_and(|node| matches!(node, parse::NodeTokens::Doctype { .. })) {
+        nodes.remove(0);
+    }
 
     let mut should_insert_doctype = nodes.first().is_some_and(|node| match node {
         /* starting with <html>..., without <!DOCTYPE html> */        

--- a/uibeam_macros/src/ui/transform.rs
+++ b/uibeam_macros/src/ui/transform.rs
@@ -277,9 +277,13 @@ pub(super) fn transform(
                 _doctype,
                 _html,
                 _end,
-            } => {
-                piece.join(Piece::new("<!DOCTYPE html>"));
-            }
+            } => (/*
+                Skip transforming here and later insert it to the output
+                (in `expand` in mod.rs).
+                This enables an optimization at performance by directly
+                concatinating `<!DOCTYPE html>` at the begenning of `<html...`
+                literal piece.
+            */),
             NodeTokens::EnclosingTag {
                 _start_open,
                 tag,


### PR DESCRIPTION
Eliminating the cost of doctype-concatination as #85, but also in explicitly-written `<!DOCTYPE html>`. 