### PR TITLE
fix(UI): surround each Beam field by `()` before call `.into()` in native `UI!`

### DIFF
--- a/uibeam_macros/src/ui/transform/native.rs
+++ b/uibeam_macros/src/ui/transform/native.rs
@@ -252,7 +252,8 @@ pub(crate) fn transform(
                     }
                 };
                 quote! {
-                    #name: #value.into(),
+                    #[allow(unused_braces)]
+                    #name: (#value).into(),
                 }
             });
             let children = content.map(|c| {


### PR DESCRIPTION
Current native `UI!` *just* applies `.into()` for field ( = attribute ) values of `Beam`s.

But this sometimes leads to not desired result:

```rust
UI! {
    <Counter init={my_init + 10} />
}
```

This code is expanded to:

```rust
Counter {
    init: my_init + 10.into(),
}
```

here `.into()` is only called for the right operand of `+`.

This PR fixes this to have the expression surrounded in `( )`:

```rust
Counter {
    init: (my_init + 10).into(),
}
```