### PR TITLE
perf: use direct import for `preact/hooks` and add modulepreload link for it

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,5 +1,0 @@
-// Project-local debug tasks
-//
-// For more documentation on how to configure debug tasks,
-// see: https://zed.dev/docs/debugger
-[]

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ fn main() {
 
 ### note
 
-Currently UIBeam's client component system is built upon [`Preact`](https://preactjs.com).
+Currently UIBeam's client component system is built upon [Preact](https://preactjs.com).
 This may be rewritten in pure Rust in the future, but may not because of potential reduction in the final .wasm size.
 
 ### usage

--- a/examples/counter/components/expected.pretty.html
+++ b/examples/counter/components/expected.pretty.html
@@ -6,12 +6,13 @@
     {
       "imports": {
         "preact": "https://esm.sh/preact@10.28.0",
-        "preact/": "https://esm.sh/preact@10.28.0/",
+        "preact/hooks": "https://esm.sh/preact@10.28.0/hooks?external=preact",
         "@preact/signals": "https://esm.sh/@preact/signals@2.5.1?external=preact"
       }
     }
     </script>
     <link rel="modulepreload" href="https://esm.sh/preact@10.28.0"/>
+    <link rel="modulepreload" href="https://esm.sh/preact@10.28.0/hooks?external=preact"/>
     <link rel="modulepreload" href="https://esm.sh/@preact/signals@2.5.1?external=preact"/>
   </head>
   <body>

--- a/uibeam_macros/src/lib.rs
+++ b/uibeam_macros/src/lib.rs
@@ -133,7 +133,7 @@ pub fn UI(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// ### note
 ///
-/// Currently UIBeam's client component system is built upon [`Preact`](https://preactjs.com).
+/// Currently UIBeam's client component system is built upon [Preact](https://preactjs.com).
 /// This may be rewritten in pure Rust in the future, but may not because of potential reduction in the final .wasm size.
 ///
 /// ### usage

--- a/uibeam_macros/src/ui/parse.rs
+++ b/uibeam_macros/src/ui/parse.rs
@@ -299,11 +299,14 @@ impl Parse for NodeTokens {
                 head_children.extend([
                         ContentPieceTokens::Node(syn::parse_quote! {
                             <script type="importmap">
-                                r#"{"imports": {"preact": "https://esm.sh/preact@10.28.0", "preact/": "https://esm.sh/preact@10.28.0/", "@preact/signals": "https://esm.sh/@preact/signals@2.5.1?external=preact"}}"#
+                                r#"{"imports": {"preact": "https://esm.sh/preact@10.28.0", "preact/hooks": "https://esm.sh/preact@10.28.0/hooks?external=preact", "@preact/signals": "https://esm.sh/@preact/signals@2.5.1?external=preact"}}"#
                             </script>
                         }),
                         ContentPieceTokens::Node(syn::parse_quote! {
                             <link rel="modulepreload" href="https://esm.sh/preact@10.28.0" />
+                        }),
+                        ContentPieceTokens::Node(syn::parse_quote! {
+                            <link rel="modulepreload" href="https://esm.sh/preact@10.28.0/hooks?external=preact" />
                         }),
                         ContentPieceTokens::Node(syn::parse_quote! {
                             <link rel="modulepreload" href="https://esm.sh/@preact/signals@2.5.1?external=preact" />


### PR DESCRIPTION
Changes the importmap entry from:

```
"preact/": "https://esm.sh/preact@10.28.0/",
```

to:

```
"preact/hooks": "https://esm.sh/preact@10.28.0/hooks?external=preact",
```

in the importmap, and adds corresponding `<link rel="modulepreload" href="https://esm.sh/preact@10.28.0/hooks?external=preact">`.

Since `/hooks` is the only submodule required in this case, and then this direct reference reduces redundant HTTP requests and redirects.